### PR TITLE
Fix outdated library dependencies

### DIFF
--- a/phylodeep/ci_comput.py
+++ b/phylodeep/ci_comput.py
@@ -259,8 +259,8 @@ def ci_comp(pred_vals, model, resc_factor, nb_tips, tr_size, samp_proba, vector_
     # add ci values to the output table
     ci_2_5 = pd.DataFrame(data=[ci_2_5], columns=PREDICTED_NAMES[model], index=[CI_2_5])
     ci_97_5 = pd.DataFrame(data=[ci_97_5], columns=PREDICTED_NAMES[model], index=[CI_97_5])
-    pred_vals = pred_vals.append(ci_2_5, ignore_index=True)
-    pred_vals = pred_vals.append(ci_97_5, ignore_index=True)
+    pred_vals = pd.concat([pred_vals, ci_2_5], ignore_index=True)
+    pred_vals = pd.concat([pred_vals, ci_97_5], ignore_index=True)
     pred_vals.index = [PREDICTED_VALUE, CI_2_5, CI_97_5]
 
     return pred_vals

--- a/phylodeep/model_load.py
+++ b/phylodeep/model_load.py
@@ -8,7 +8,7 @@ import numpy as np
 warnings.filterwarnings('ignore')
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
-from tensorflow.python.keras.models import model_from_json
+from tensorflow.keras.models import model_from_json
 
 
 PRETRAINED_MODELS_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'pretrained_models')


### PR DESCRIPTION
The model selection portion of the example does not run without this fix. Only applies to tensorflow version >2.12. The dependency of this library specified version >2.10 for tensorflow. 
More information here: https://github.com/tensorflow/tensorflow/issues/61215
This is what the error looks like when running the example without this fix:
![image](https://github.com/evolbioinfo/phylodeep/assets/47712557/1928d0a3-b9b6-457d-abf3-15d82cd1af35)
